### PR TITLE
feat: redesign home hero and add content stubs

### DIFF
--- a/src/main/java/io/acofitec/web/CommunitiesPageResource.java
+++ b/src/main/java/io/acofitec/web/CommunitiesPageResource.java
@@ -1,5 +1,6 @@
 package io.acofitec.web;
 
+import io.quarkus.qute.Location;
 import io.quarkus.qute.Template;
 import io.quarkus.qute.TemplateInstance;
 import jakarta.inject.Inject;
@@ -8,14 +9,16 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
-@Path("/")
-public class HomeResource {
+@Path("/comunidades")
+public class CommunitiesPageResource {
 
-  @Inject Template index;
+  @Inject
+  @Location("comunidades/list.stub")
+  Template comunidadesListStub;
 
   @GET
   @Produces(MediaType.TEXT_HTML)
-  public TemplateInstance home() {
-    return index.instance();
+  public TemplateInstance comunidades() {
+    return comunidadesListStub.instance();
   }
 }

--- a/src/main/java/io/acofitec/web/EventsPageResource.java
+++ b/src/main/java/io/acofitec/web/EventsPageResource.java
@@ -1,5 +1,6 @@
 package io.acofitec.web;
 
+import io.quarkus.qute.Location;
 import io.quarkus.qute.Template;
 import io.quarkus.qute.TemplateInstance;
 import jakarta.inject.Inject;
@@ -8,14 +9,16 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
-@Path("/")
-public class HomeResource {
+@Path("/eventos")
+public class EventsPageResource {
 
-  @Inject Template index;
+  @Inject
+  @Location("eventos/list.stub")
+  Template eventosListStub;
 
   @GET
   @Produces(MediaType.TEXT_HTML)
-  public TemplateInstance home() {
-    return index.instance();
+  public TemplateInstance eventos() {
+    return eventosListStub.instance();
   }
 }

--- a/src/main/java/io/acofitec/web/ProjectsPageResource.java
+++ b/src/main/java/io/acofitec/web/ProjectsPageResource.java
@@ -1,5 +1,6 @@
 package io.acofitec.web;
 
+import io.quarkus.qute.Location;
 import io.quarkus.qute.Template;
 import io.quarkus.qute.TemplateInstance;
 import jakarta.inject.Inject;
@@ -8,14 +9,16 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
-@Path("/")
-public class HomeResource {
+@Path("/proyectos")
+public class ProjectsPageResource {
 
-  @Inject Template index;
+  @Inject
+  @Location("proyectos/list.stub")
+  Template proyectosListStub;
 
   @GET
   @Produces(MediaType.TEXT_HTML)
-  public TemplateInstance home() {
-    return index.instance();
+  public TemplateInstance proyectos() {
+    return proyectosListStub.instance();
   }
 }

--- a/src/main/resources/META-INF/resources/css/main.css
+++ b/src/main/resources/META-INF/resources/css/main.css
@@ -1,8 +1,10 @@
 :root {
   --primary: #1f6feb;
   --text-color: #1f2933;
+  --muted-color: #475569;
   --background: #f8fafc;
   --surface: #ffffff;
+  --shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
 }
 
 * {
@@ -15,6 +17,15 @@ body {
   color: var(--text-color);
   background: var(--background);
   line-height: 1.6;
+}
+
+a {
+  color: inherit;
+}
+
+a:focus-visible {
+  outline: 3px solid rgba(31, 111, 235, 0.45);
+  outline-offset: 3px;
 }
 
 img {
@@ -67,7 +78,6 @@ img {
 
 .site-nav a {
   text-decoration: none;
-  color: inherit;
   font-weight: 500;
   transition: color 0.2s ease;
 }
@@ -77,55 +87,134 @@ img {
 }
 
 .site-main {
-  padding: 3rem 0;
+  padding: 3.5rem 0 4rem;
 }
 
 .hero {
+  padding-bottom: 3rem;
+}
+
+.hero-content {
   display: grid;
-  gap: 2rem;
-  align-items: center;
-  min-height: 50vh;
+  gap: 1.75rem;
+  max-width: 52rem;
 }
 
-.hero-text h1 {
+.hero-content h1 {
   font-size: clamp(2.5rem, 5vw, 3.5rem);
-  margin-bottom: 1rem;
+  margin: 0;
 }
 
-.hero-text p {
+.hero-subtitle {
   font-size: 1.125rem;
-  max-width: 32rem;
+  color: var(--muted-color);
+  margin: 0;
+  max-width: 36rem;
+}
+
+.hero-actions {
+  display: flex;
+  align-items: center;
 }
 
 .cta {
   display: inline-block;
-  margin-top: 1.5rem;
-  padding: 0.875rem 1.75rem;
+  padding: 0.9rem 1.9rem;
   background: var(--primary);
-  color: white;
+  color: #ffffff;
   border-radius: 999px;
   font-weight: 600;
   text-decoration: none;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.cta:hover {
+.cta:hover,
+.cta:focus-visible {
   transform: translateY(-2px);
-  box-shadow: 0 8px 20px rgba(31, 111, 235, 0.25);
+  box-shadow: 0 12px 24px rgba(31, 111, 235, 0.25);
 }
 
-.highlights {
+.axes {
   display: grid;
-  gap: 1.5rem;
-  margin-top: 4rem;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 2.5rem;
 }
 
-.highlights article {
+.section-header {
+  max-width: 48rem;
+}
+
+.section-header h2 {
+  font-size: clamp(1.75rem, 3vw, 2.25rem);
+  margin: 0 0 0.75rem;
+}
+
+.section-header p {
+  margin: 0;
+  color: var(--muted-color);
+}
+
+.axes-grid {
+  display: grid;
+  gap: 1.75rem;
+  grid-template-columns: 1fr;
+}
+
+.axis-card {
   background: var(--surface);
-  padding: 1.75rem;
+  padding: 2rem;
   border-radius: 1rem;
-  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.05);
+  box-shadow: var(--shadow);
+  display: grid;
+  gap: 1rem;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.axis-card:hover,
+.axis-card:focus-within {
+  transform: translateY(-6px);
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.14);
+}
+
+.axis-icon {
+  font-size: 2rem;
+}
+
+.axis-card h3 {
+  margin: 0;
+  font-size: 1.35rem;
+}
+
+.axis-card p {
+  margin: 0;
+  color: var(--muted-color);
+}
+
+.axis-link {
+  justify-self: flex-start;
+  font-weight: 600;
+  text-decoration: none;
+  color: var(--primary);
+}
+
+.axis-link:hover,
+.axis-link:focus-visible {
+  text-decoration: underline;
+}
+
+.page-stub {
+  display: grid;
+  gap: 1rem;
+  max-width: 48rem;
+}
+
+.page-stub h1 {
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 2.5rem);
+}
+
+.page-stub p {
+  margin: 0;
+  color: var(--muted-color);
 }
 
 .about {
@@ -158,7 +247,8 @@ img {
   text-decoration: none;
 }
 
-.footer-links a:hover {
+.footer-links a:hover,
+.footer-links a:focus-visible {
   text-decoration: underline;
 }
 
@@ -171,5 +261,17 @@ img {
   .site-nav {
     flex-wrap: wrap;
     justify-content: center;
+  }
+}
+
+@media (min-width: 640px) {
+  .axes-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 960px) {
+  .axes-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 }

--- a/src/main/resources/templates/comunidades/list.stub.qute.html
+++ b/src/main/resources/templates/comunidades/list.stub.qute.html
@@ -1,0 +1,7 @@
+{@layout layout}
+{#let title='Comunidades — Acofitec', description='Muy pronto podrás conocer las comunidades que integran Acofitec.' /}
+
+<section class="page-stub">
+  <h1>Pronto: Listado de comunidades</h1>
+  <p>Estamos conectando grupos de estudiantes y profesionales para compartirlos contigo.</p>
+</section>

--- a/src/main/resources/templates/eventos/list.stub.qute.html
+++ b/src/main/resources/templates/eventos/list.stub.qute.html
@@ -1,0 +1,7 @@
+{@layout layout}
+{#let title='Eventos — Acofitec', description='Pronto encontrarás el calendario de eventos de Acofitec.' /}
+
+<section class="page-stub">
+  <h1>Pronto: Listado de eventos</h1>
+  <p>Estamos preparando conferencias, charlas y workshops para compartir muy pronto.</p>
+</section>

--- a/src/main/resources/templates/index.qute.html
+++ b/src/main/resources/templates/index.qute.html
@@ -1,27 +1,45 @@
 {@layout layout}
+{#let title='Acofitec — Comunidad, Eventos y Open Source', description='Impulsamos la innovación con comunidad y colaboración.', subtitle='Impulsamos la innovación con comunidad y colaboración.', heroTitle='Acofitec' /}
 
-<section class="hero">
-  <div class="hero-text">
-    <h1>Innovación con comunidad</h1>
-    <p>
-      Acofitec conecta a personas, organizaciones y proyectos para acelerar el
-      impacto tecnológico en la región.
-    </p>
-    <a class="cta" href="#">Únete</a>
+<section class="hero" aria-labelledby="home-hero-title">
+  <div class="hero-content">
+    <h1 id="home-hero-title">{heroTitle ?: title ?: 'Acofitec'}</h1>
+    <p class="hero-subtitle">{subtitle ?: 'Impulsamos la innovación con comunidad y colaboración.'}</p>
+    <div class="hero-actions">
+      <a
+        class="cta"
+        href="/contacto"
+        title="Ir a la página de contacto de Acofitec"
+        aria-label="Únete a la comunidad Acofitec"
+        >Únete</a
+      >
+    </div>
   </div>
 </section>
 
-<section class="highlights">
-  <article>
-    <h2>Aprende y comparte</h2>
-    <p>Charlas, talleres y espacios de colaboración abiertos a la comunidad.</p>
-  </article>
-  <article>
-    <h2>Construye proyectos</h2>
-    <p>Impulsa iniciativas con propósito junto a personas con talentos diversos.</p>
-  </article>
-  <article>
-    <h2>Conecta comunidades</h2>
-    <p>Tejemos redes que potencian el crecimiento de la industria tecnológica.</p>
-  </article>
+<section class="axes" aria-labelledby="axes-heading">
+  <div class="section-header">
+    <h2 id="axes-heading">Explora nuestros ejes</h2>
+    <p>Conecta con experiencias, personas y proyectos que impulsan la innovación.</p>
+  </div>
+  <div class="axes-grid">
+    <article class="axis-card">
+      <div class="axis-icon" aria-hidden="true">🎤</div>
+      <h3>Eventos</h3>
+      <p>Explora conferencias, charlas y workshops.</p>
+      <a class="axis-link" href="/eventos" title="Explorar eventos de Acofitec">Explorar</a>
+    </article>
+    <article class="axis-card">
+      <div class="axis-icon" aria-hidden="true">🤝</div>
+      <h3>Comunidades</h3>
+      <p>Conecta con grupos de estudiantes y profesionales.</p>
+      <a class="axis-link" href="/comunidades" title="Explorar comunidades de Acofitec">Explorar</a>
+    </article>
+    <article class="axis-card">
+      <div class="axis-icon" aria-hidden="true">🛠️</div>
+      <h3>Proyectos</h3>
+      <p>Descubre y contribuye a iniciativas open source.</p>
+      <a class="axis-link" href="/proyectos" title="Explorar proyectos de Acofitec">Explorar</a>
+    </article>
+  </div>
 </section>

--- a/src/main/resources/templates/layout.qute.html
+++ b/src/main/resources/templates/layout.qute.html
@@ -3,16 +3,11 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>{title ?: 'Acofitec'}</title>
-    <meta
-      name="description"
-      content="{description ?: 'Impulsamos la innovación con comunidad y colaboración.'}"
-    />
-    <meta property="og:title" content="{title ?: 'Acofitec'}" />
-    <meta
-      property="og:description"
-      content="{description ?: 'Impulsamos la innovación con comunidad y colaboración.'}"
-    />
+    {#let pageTitle=title ?: 'Acofitec', pageDescription=description ?: 'Impulsamos la innovación con comunidad y colaboración.' /}
+    <title>{pageTitle}</title>
+    <meta name="description" content="{pageDescription}" />
+    <meta property="og:title" content="{pageTitle}" />
+    <meta property="og:description" content="{pageDescription}" />
     <meta property="og:type" content="website" />
     <link rel="stylesheet" href="/css/main.css" />
   </head>

--- a/src/main/resources/templates/proyectos/list.stub.qute.html
+++ b/src/main/resources/templates/proyectos/list.stub.qute.html
@@ -1,0 +1,7 @@
+{@layout layout}
+{#let title='Proyectos — Acofitec', description='Pronto podrás sumarte a los proyectos colaborativos de Acofitec.' /}
+
+<section class="page-stub">
+  <h1>Pronto: Listado de proyectos</h1>
+  <p>Estamos impulsando iniciativas open source y pronto podrás explorarlas aquí.</p>
+</section>


### PR DESCRIPTION
## Summary
- implement a hero with CTA and responsive grid of event, community, and project cards on the home page
- refresh base layout metadata handling and styling for hero, cards, focus outlines, and stubs
- add temporary templates and resources for /eventos, /comunidades, and /proyectos routes

## Testing
- ./mvnw -q test *(fails: network is unreachable while downloading Maven wrapper distribution)*

------
https://chatgpt.com/codex/tasks/task_e_68d88e8e8e7c833385323189816dc7e7