### PR TITLE
Add mock security profile for local dev without OIDC

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,29 @@ principales:
 - `/` Página de inicio con hero, CTA y navegación.
 - `/sobre` Página con Visión y Misión de Acofitec.
 
+### Identidad simulada en desarrollo
+
+En los perfiles `dev` y `test` no es necesario tener un servidor OIDC en ejecución.
+El proyecto expone una identidad mock configurable que emula la información básica
+que entregaría el proveedor real.
+
+Valores por defecto en modo `dev`:
+
+- Usuario: `developer`
+- Roles: `admin`, `user`
+- Email: `developer@acofitec.local`
+- Subject: `00000000-0000-0000-0000-000000000001`
+
+Puedes modificar la identidad en caliente a través de los siguientes headers
+HTTP al invocar los endpoints protegidos:
+
+- `X-Mock-User`: nombre de usuario a utilizar.
+- `X-Mock-Roles`: lista de roles separada por comas.
+- `Authorization`: token (se acepta tanto un valor libre como `Bearer <token>`).
+
+En caso de necesitar otros atributos puedes ajustarlos en `application.properties`
+utilizando el prefijo `acofitec.security.mock`.
+
 ## Build del proyecto
 
 Genera el paquete ejecutable omitiendo tests (no se incluyen aún):

--- a/src/main/java/io/acofitec/security/MockSecurityConfig.java
+++ b/src/main/java/io/acofitec/security/MockSecurityConfig.java
@@ -1,0 +1,24 @@
+package io.acofitec.security;
+
+import java.util.List;
+import java.util.Optional;
+
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+
+@ConfigMapping(prefix = "acofitec.security.mock")
+public interface MockSecurityConfig {
+
+    @WithDefault("false")
+    boolean enabled();
+
+    @WithDefault("dev-user")
+    String username();
+
+    @WithDefault("user")
+    List<String> roles();
+
+    Optional<String> email();
+
+    Optional<String> subject();
+}

--- a/src/main/java/io/acofitec/security/MockSecurityFilter.java
+++ b/src/main/java/io/acofitec/security/MockSecurityFilter.java
@@ -1,0 +1,116 @@
+package io.acofitec.security;
+
+import java.security.Principal;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.ext.Provider;
+
+import io.quarkus.arc.profile.IfBuildProfile;
+import io.quarkus.security.runtime.QuarkusSecurityIdentity;
+import io.quarkus.security.runtime.SecurityIdentityAssociation;
+
+/**
+ * Provides a deterministic security identity while developing or executing tests
+ * without depending on an external OIDC provider. The identity can be customised
+ * through HTTP headers so that different scenarios can be simulated locally.
+ */
+@Provider
+@Priority(Priorities.AUTHENTICATION)
+@ApplicationScoped
+@IfBuildProfile(anyOf = { "dev", "test" })
+public class MockSecurityFilter implements ContainerRequestFilter {
+
+    public static final String USER_HEADER = "X-Mock-User";
+    public static final String ROLES_HEADER = "X-Mock-Roles";
+    public static final String TOKEN_HEADER = "Authorization";
+
+    private final SecurityIdentityAssociation identityAssociation;
+    private final MockSecurityConfig config;
+
+    @Inject
+    public MockSecurityFilter(SecurityIdentityAssociation identityAssociation, MockSecurityConfig config) {
+        this.identityAssociation = identityAssociation;
+        this.config = config;
+    }
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) {
+        if (!config.enabled()) {
+            return;
+        }
+
+        QuarkusSecurityIdentity.Builder identity = QuarkusSecurityIdentity.builder();
+        identity.setPrincipal(new SimplePrincipal(resolveUsername(requestContext)));
+        identity.setAnonymous(false);
+        resolveRoles(requestContext).forEach(identity::addRole);
+
+        String token = extractBearerToken(requestContext);
+        if (token != null) {
+            identity.addAttribute("token", token);
+        }
+
+        config.email().ifPresent(email -> identity.addAttribute("email", email));
+        config.subject().ifPresent(subject -> identity.addAttribute("subject", subject));
+
+        identityAssociation.setIdentity(identity.build());
+    }
+
+    private String resolveUsername(ContainerRequestContext context) {
+        String fromHeader = context.getHeaderString(USER_HEADER);
+        if (fromHeader != null && !fromHeader.isBlank()) {
+            return fromHeader.trim();
+        }
+        return config.username();
+    }
+
+    private Set<String> resolveRoles(ContainerRequestContext context) {
+        String fromHeader = context.getHeaderString(ROLES_HEADER);
+        if (fromHeader == null || fromHeader.isBlank()) {
+            return new LinkedHashSet<>(config.roles());
+        }
+        Set<String> roles = new LinkedHashSet<>();
+        Arrays.stream(fromHeader.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .forEach(roles::add);
+        return roles;
+    }
+
+    private String extractBearerToken(ContainerRequestContext context) {
+        String authorization = context.getHeaderString(TOKEN_HEADER);
+        if (authorization == null || authorization.isBlank()) {
+            return null;
+        }
+        if (authorization.regionMatches(true, 0, "Bearer ", 0, 7)) {
+            String token = authorization.substring(7).trim();
+            return token.isEmpty() ? null : token;
+        }
+        return authorization.trim();
+    }
+
+    private static final class SimplePrincipal implements Principal {
+        private final String name;
+
+        private SimplePrincipal(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public String toString() {
+            return name;
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,3 +3,15 @@ quarkus.oidc.client-id=${OIDC_CLIENT_ID:dev}
 quarkus.oidc.credentials.secret=${OIDC_CLIENT_SECRET:dev}
 quarkus.oidc.auth-server-url=${OIDC_AUTH_SERVER_URL:http://localhost/oidc}
 quarkus.oidc.application-type=web-app
+
+%dev.quarkus.oidc.enabled=false
+%test.quarkus.oidc.enabled=false
+
+%dev.acofitec.security.mock.enabled=true
+%test.acofitec.security.mock.enabled=true
+%dev.acofitec.security.mock.username=developer
+%dev.acofitec.security.mock.roles=admin,user
+%dev.acofitec.security.mock.email=developer@acofitec.local
+%dev.acofitec.security.mock.subject=00000000-0000-0000-0000-000000000001
+%test.acofitec.security.mock.username=tester
+%test.acofitec.security.mock.roles=user


### PR DESCRIPTION
## Summary
- add a dev/test security filter that builds a mock identity without contacting an OIDC server
- expose configuration properties to toggle the mock user and disable quarkus-oidc for dev and test profiles
- document how to override the simulated identity while running locally

## Testing
- ./mvnw -q compile *(fails: network unreachable while downloading Maven Wrapper dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68da9adc318083339f58b1422b3cedee