### PR TITLE
chore: remove bundled og placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,35 @@ que podrás definir según tu entorno:
 - `OIDC_AUTH_SERVER_URL` (por defecto `http://localhost/oidc`).
 
 Estas variables sirven como placeholders para futuras integraciones OIDC.
+
+## SEO v1
+
+El layout principal (`src/main/resources/templates/layout.qute.html`) incluye metadatos
+SEO mínimos con valores por defecto:
+
+- `title`: `Acofitec — Comunidad, Eventos y Open Source`.
+- `description`: `Impulsamos la innovación con comunidad y colaboración.`
+- `canonical`: `/`.
+- `ogImage`: `/brand/acofitec-logo.svg`.
+
+Puedes sobreescribir cualquiera de estas variables desde cada vista Qute con un bloque
+`{#let}` al inicio del template o enviándolas desde el controlador en el modelo. Ejemplo
+directo en el template:
+
+```qute-html
+{#let
+  title='Acofitec — Comunidad, Eventos y Open Source'
+  description='Conectamos personas, eventos y proyectos para aprender, crear y crecer.'
+  canonical='/'
+  ogImage='/brand/acofitec-logo.svg'
+/}
+<!-- resto del template -->
+{/let}
+```
+
+Los archivos estáticos `sitemap.xml` y `robots.txt` se encuentran en
+`src/main/resources/META-INF/resources/` y se sirven desde `/sitemap.xml` y
+`/robots.txt` respectivamente. Por defecto se reutiliza `brand/acofitec-logo.svg`
+como imagen OpenGraph/Twitter; puedes reemplazarla aportando una ruta diferente
+mediante la variable `ogImage` o incorporando un asset propio en el mismo
+directorio (agregándolo fuera de este PR si necesitas un PNG dedicado).

--- a/src/main/resources/META-INF/resources/robots.txt
+++ b/src/main/resources/META-INF/resources/robots.txt
@@ -1,0 +1,4 @@
+# Actualizar dominio absoluto en prod vía reversa/ingress si aplica
+User-agent: *
+Allow: /
+Sitemap: /sitemap.xml

--- a/src/main/resources/META-INF/resources/sitemap.xml
+++ b/src/main/resources/META-INF/resources/sitemap.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- v1 estático; se reemplazará por versión dinámica cuando existan slugs -->
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>/sobre</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>/eventos</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>/comunidades</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>/proyectos</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>/contacto</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+</urlset>

--- a/src/main/resources/templates/layout.qute.html
+++ b/src/main/resources/templates/layout.qute.html
@@ -3,16 +3,18 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    {#let
-      pageTitle=(title ?: 'Acofitec')
-      pageDescription=(description ?: 'Impulsamos la innovación con comunidad y colaboración.')
-    }
-    <title>{pageTitle}</title>
-    <meta name="description" content="{pageDescription}" />
-    <meta property="og:title" content="{pageTitle}" />
-    <meta property="og:description" content="{pageDescription}" />
-    {/let}
+    <title>{title ?: 'Acofitec — Comunidad, Eventos y Open Source'}</title>
+    <meta name="description" content="{description ?: 'Impulsamos la innovación con comunidad y colaboración.'}" />
+    <link rel="canonical" href="{canonical ?: '/'}" />
+    <meta property="og:title" content="{title ?: 'Acofitec — Comunidad, Eventos y Open Source'}" />
+    <meta property="og:description" content="{description ?: 'Impulsamos la innovación con comunidad y colaboración.'}" />
     <meta property="og:type" content="website" />
+    <meta property="og:url" content="{canonical ?: '/'}" />
+    <meta property="og:image" content="{ogImage ?: '/brand/acofitec-logo.svg'}" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="{title ?: 'Acofitec — Comunidad, Eventos y Open Source'}" />
+    <meta name="twitter:description" content="{description ?: 'Impulsamos la innovación con comunidad y colaboración.'}" />
+    <meta name="twitter:image" content="{ogImage ?: '/brand/acofitec-logo.svg'}" />
     <link rel="stylesheet" href="/css/main.css" />
   </head>
   <body>


### PR DESCRIPTION
## Summary
- add static sitemap.xml and robots.txt with initial routes
- enhance layout metadata with SEO fallbacks and canonical/OG/Twitter tags
- document SEO variables and reuse the existing SVG logo as the default OG/Twitter image to keep the PR code-only

## Testing
- `./mvnw -DskipTests package` *(fails: network is unreachable when Maven wrapper tries to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68dbb0c66b4c8333b4ababa57ffef499